### PR TITLE
Use React & ReactDOM from wp-core

### DIFF
--- a/customize-react-street-address-control.php
+++ b/customize-react-street-address-control.php
@@ -21,7 +21,7 @@ add_action( 'customize_controls_enqueue_scripts', function() {
 
 	$handle = 'customize-react-street-address-control';
 	$src = plugin_dir_url( __FILE__ ) . 'build/static/js/' . basename( array_shift( $build_js ) );
-	$deps = array( 'customize-controls' );
+	$deps = array( 'customize-controls', 'wp-element' );
 	wp_enqueue_script( $handle, $src, $deps );
 } );
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,7 @@
   "name": "customize-react-street-address-control",
   "version": "0.1.0",
   "private": true,
-  "dependencies": {
-    "react": "^16.1.1",
-    "react-dom": "^16.1.1",
-    "react-scripts": "1.0.17"
-  },
+  "dependencies": {},
   "homepage": "https://xwp.github.io/wp-customize-react-street-address-control/",
   "scripts": {
     "start": "react-scripts start",

--- a/src/StreetAddressControl.jsx
+++ b/src/StreetAddressControl.jsx
@@ -1,6 +1,4 @@
-/* global wp, jQuery */
-import React from 'react';
-import ReactDOM from 'react-dom';
+/* global wp, jQuery, React, ReactDOM */
 import StreetAddressForm from './StreetAddressForm';
 
 /**

--- a/src/StreetAddressForm.jsx
+++ b/src/StreetAddressForm.jsx
@@ -1,5 +1,4 @@
-/* globals _, console */
-import React from 'react';
+/* globals _, console, React */
 
 const StreetAddressForm = ( props ) => {
 	const idPrefix = _.uniqueId();


### PR DESCRIPTION
This PR just uses the WP-included versions of React & ReactDOM.
When this repo was created WP5.0 was still a distant dream, but now that we have these in wp-core there's no need to bundle them in the control itself.